### PR TITLE
client.Do saves resp.Body; Debug bool in Client type

### DIFF
--- a/yamusic/yamusic.go
+++ b/yamusic/yamusic.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -29,6 +30,8 @@ type (
 		// Access token to Yandex.Music API
 		accessToken string
 		userID      int
+		// Debug sets should library print debug messages or not
+		Debug bool
 		// Services
 		genres    *GenresService
 		search    *SearchService
@@ -36,6 +39,10 @@ type (
 		feed      *FeedService
 		playlists *PlaylistsService
 	}
+)
+
+var (
+	debl = log.New(os.Stdout, "[debug]\t", log.Ldate|log.Ltime|log.Lshortfile)
 )
 
 // NewClient returns a new API client.
@@ -161,13 +168,6 @@ func (c *Client) Do(
 		return nil, err
 	}
 
-	defer func() {
-		closeErr := resp.Body.Close()
-		if closeErr != nil {
-			log.Println("close response body error: ", closeErr)
-		}
-	}()
-
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {
 			_, err = io.Copy(w, resp.Body)
@@ -175,7 +175,15 @@ func (c *Client) Do(
 				return nil, err
 			}
 		} else {
-			err = json.NewDecoder(resp.Body).Decode(v)
+			dat, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewReader(dat))
+			if c.Debug {
+				debl.Println("Got empty")
+			}
+			err = json.Unmarshal(dat, v)
 			if err == io.EOF {
 				err = nil // ignore EOF errors caused by empty response body
 			}

--- a/yamusic/yamusic.go
+++ b/yamusic/yamusic.go
@@ -42,7 +42,7 @@ type (
 )
 
 var (
-	deblog = log.New(os.Stdout, "[debug]\t", log.Ldate|log.Ltime|log.Lshortfile)
+	deblog = log.New(os.Stdout, "[DEBUG]\t", log.Ldate|log.Ltime|log.Lshortfile)
 )
 
 // NewClient returns a new API client.

--- a/yamusic/yamusic.go
+++ b/yamusic/yamusic.go
@@ -42,7 +42,7 @@ type (
 )
 
 var (
-	debl = log.New(os.Stdout, "[debug]\t", log.Ldate|log.Ltime|log.Lshortfile)
+	deblog = log.New(os.Stdout, "[debug]\t", log.Ldate|log.Ltime|log.Lshortfile)
 )
 
 // NewClient returns a new API client.
@@ -180,11 +180,11 @@ func (c *Client) Do(
 				return nil, err
 			}
 			resp.Body = io.NopCloser(bytes.NewReader(dat))
-			if c.Debug {
-				debl.Println("Got empty")
-			}
 			err = json.Unmarshal(dat, v)
 			if err == io.EOF {
+				if c.Debug {
+					deblog.Println("Got empty")
+				}
 				err = nil // ignore EOF errors caused by empty response body
 			}
 		}


### PR DESCRIPTION
1) If resp wasn't io.Reader, client.Do used to return resp with closed body; now it doesn't
2) I've added logger for debugging in `debl` variable. Also I've added bool field `Debug` in Client structure to show debug messages only when this variable is true. Now it's using in client.Do, later it may be added to other functions if they need that